### PR TITLE
Fixed GetLogs return slices only have last log bug

### DIFF
--- a/sdk/ethereum/ethereum.go
+++ b/sdk/ethereum/ethereum.go
@@ -103,8 +103,8 @@ type EthereumTransactionReceipt struct {
 }
 
 func (r *EthereumTransactionReceipt) GetLogs() (rst []sdk.IReceiptLog) {
-	for _, log := range r.Logs {
-		l := ReceiptLog{&log}
+	for i:= range r.Logs {
+		l := ReceiptLog{&r.Logs[i]}
 		rst = append(rst, l)
 	}
 


### PR DESCRIPTION
ref: https://stackoverflow.com/questions/48826460/using-pointers-in-a-for-loop-golang